### PR TITLE
accept percentage spyOffset, prepend <ul> to nav

### DIFF
--- a/src/anchorific.js
+++ b/src/anchorific.js
@@ -62,14 +62,14 @@ if ( typeof Object.create !== 'function' ) {
 			top: '.top', // back to top button or link class
 			spy: true, // scroll spy
 			position: 'append', // position of anchor text
-			spyOffset: !0 // specify heading offset for spy scrolling
+			spyOffset: !0 // specify heading offset for spy scrolling (px as numbers eg.90 || percentage as string eg.'90%')
 		},
 		
 		build: function() {
 			var self = this, obj, navigations = function() {};
 			// when navigation configuration is set
 			if ( self.opt.navigation ) {
-				$( self.opt.navigation ).append( '<ul />' );
+				$( self.opt.navigation ).prepend( '<ul />' );
 				self.previous = $( self.opt.navigation ).find( 'ul' ).last();
 				navigations = function( obj ) {
 					return self.navigations( obj );
@@ -179,7 +179,12 @@ if ( typeof Object.create !== 'function' ) {
 				self.top( this );
 				// get all the header on top of the viewport
 				current = self.headers.map( function( e ) {
-					if ( ( $( this ).offset().top - $( window ).scrollTop() ) < self.opt.spyOffset ) {
+					// check if spyOffset is a percentage value and calculate offset
+					var spyOffsetCalculated = self.opt.spyOffset;
+					if ( self.opt.spyOffset.indexOf("%") >= 0 ) {
+						spyOffsetCalculated = parseFloat(self.opt.spyOffset) * $ ( window ).height() / 100;
+					}
+					if ( ( $( this ).offset().top - $( window ).scrollTop() ) < spyOffsetCalculated ) {
 						return this;
 					}
 				});

--- a/src/anchorific.js
+++ b/src/anchorific.js
@@ -43,7 +43,7 @@ if ( typeof Object.create !== 'function' ) {
 
 			self.opt = $.extend( {},  this.opt, options );
 
-			self.headers = self.$elem.find( 'h1, h2, h3, h4, h5, h6' );
+			self.headers = self.$elem.find( self.opt.headers );
 			self.previous = 0;
 
 			// Fix bug #1
@@ -65,7 +65,8 @@ if ( typeof Object.create !== 'function' ) {
 			spyOffset: !0, // sets an offset (as string if percentage) for highlighting sections
 			throttled: true, // throttles window bound functions such as scroll and resize for performance
 			throttleDelay: 50, // the time interval in which throttled functions are fired (in miliseconds)
-			requireScrollPastTarget: true // checks if the top of the window is past the target content element for highlighting, and removes highlight if scrolled up past the target content element
+			requireScrollPastTarget: true, // checks if the top of the window is past the target content element for highlighting, and removes highlight if scrolled up past the target content element
+			headers: 'h1, h2, h3, h4, h5, h6' //defines the range of headers to be parsed for the table of contents
 		},
 		
 		build: function() {


### PR DESCRIPTION
Now it accepts percentage values for spyOffset, as is more appropriate for most sites, adapting to window height. `<ul>` is prepended to target `<nav>` instead of appended, relocating back to top link to bottom as appropriate and less glitchy when it is added/removed by `css(display:none;)`
