### PR TITLE
Quick fix for issue #13

### DIFF
--- a/src/anchorific.js
+++ b/src/anchorific.js
@@ -34,6 +34,9 @@ if ( typeof Object.create !== 'function' ) {
 	"use strict";
 
 	var Anchorific = {
+		
+		// array of unique slug names
+        	names: [],
 
 		init: function( options, elem ) {
 			var self = this;
@@ -78,8 +81,8 @@ if ( typeof Object.create !== 'function' ) {
 
 			for( var i = 0; i < self.headers.length; i++ ) {
 				obj = self.headers.eq( i );
-				navigations( obj );
 				self.anchor( obj );
+				navigations( obj );
 			}
 
 			if ( self.opt.spy )
@@ -139,6 +142,13 @@ if ( typeof Object.create !== 'function' ) {
 				obj.attr( 'id', name );
 
 			id = obj.attr( 'id' );
+			
+			while ($.inArray(id, self.names) >= 0){
+		                id += "_";
+		            }
+		
+		        obj.attr( 'id', id );
+		        self.names.push(id);
 
 			anchor = $( '<a />' ).attr( 'href', '#' + id ).html( text ).addClass( klass );
 


### PR DESCRIPTION
Quick fix for issue
https://github.com/renettarenula/anchorific.js/issues/13

An array of names is kept in memory. Unique slugs are generated by appending "_" because there might not be other ways to distinguish 2 content parts.
Also had to invert the order of anchor and navigations so that the unique ids are set on the "h" titles before the navigations function is executed. This way, navigations is grabbing the newly generated ids

Fabien
