### PR TITLE
Headings with identical content on any heading level not being handled

### DIFF
--- a/src/anchorific.js
+++ b/src/anchorific.js
@@ -34,6 +34,8 @@ if (typeof Object.create !== 'function') {
   'use strict';
 
   var Anchorific = {
+    // array of unique slug names
+    names: [],
     init: function (options, elem) {
       var self = this;
 
@@ -86,8 +88,9 @@ if (typeof Object.create !== 'function') {
 
       for (var i = 0; i < self.headers.length; i++) {
         obj = self.headers.eq(i);
-        navigations(obj);
         self.anchor(obj);
+        navigations(obj);
+        self.anchorLinks(obj);
       }
 
       if (self.opt.spy) self.spy();
@@ -151,20 +154,39 @@ if (typeof Object.create !== 'function') {
     anchor: function (obj) {
       var self = this,
         name = self.name(obj),
-        anchor,
-        text = self.opt.anchorText,
-        klass = self.opt.anchorClass,
+        num = 1,
         id;
 
-      if (obj.attr('id') === undefined) obj.attr('id', name);
+      // Set initial ID if none exists
+      if (obj.attr('id') === undefined) {
+        id = name;
+      } else {
+        id = obj.attr('id');
+      }
 
-      id = obj.attr('id');
+      // Ensure ID uniqueness
+      while ($.inArray(id, self.names) >= 0) {
+        id = name + '-' + num;
+        num++;
+      }
 
-      anchor = $('<a />')
+      obj.attr('id', id);
+      self.names.push(id);
+    },
+
+    anchorLinks: function (obj) {
+      var self = this,
+        text = self.opt.anchorText,
+        klass = self.opt.anchorClass,
+        id = obj.attr('id');
+
+      // Create anchor element
+      var anchor = $('<a />')
         .attr('href', '#' + id)
         .html(text)
         .addClass(klass);
 
+      // Insert anchor based on position setting
       if (self.opt.position === 'append') {
         obj.append(anchor);
       } else {


### PR DESCRIPTION
Extending on **fnicollet's** patch to handle headings with identical content https://github.com/renettarenula/anchorific.js/pull/14

Changes:
- Added multi-level handling of identical content within heading elements
- Split off **anchor** method into **anchor** and **anchorLink** methods to give each a defined responsibility and order of processing headings